### PR TITLE
实现优酷分段视频连续播放的功能

### DIFF
--- a/seed.js
+++ b/seed.js
@@ -131,6 +131,18 @@
         element.innerHTML = html;
         markVideoUrl(url);
 
+		document.getElementById("my_video_1").addEventListener("ended", 
+			function(e) {
+				idSeg = document.getElementById("html5-player-seg");
+				var cur = parseInt(idSeg.getElementsByClassName("current")[0].innerHTML);
+				var len = idSeg.getElementsByTagName("a").length;
+				log("Event ended comes: cur=" + cur + " len=" + len);
+				if (cur < len) {
+					idSeg.getElementsByTagName("a")[cur].click();
+				}
+			}
+		);
+		
         loadCSS(PLAYER_CSS_URL);
         getScript(PLAYER_SCRIPT_URL, success);
     };


### PR DESCRIPTION
Listen 'ended' event of HTML5 video. When playback finished, browser would send 'ended' event, webpage side could listen to this event to do something. In this case, play next video segment.

This solution is only tested on Youku. Known issue is if in full screen mode, play next video segment would exit full screen mode. I don't know how to call vjs requestFullScreen API in event listener callback function.
